### PR TITLE
Clarifying inclusion of protocol in host_address_of_1Password_Connect…

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ $ vault secrets list
 
 ### Plugin Configuration
 
-In order to configure your plugin to access the 1Password Connect API, create a configuration json file:
+In order to configure your plugin to access the 1Password Connect API, create a configuration json file. The value for `host_address_of_1Password_Connect_API` should be prefixed by http/https:
 
 ```json
 {


### PR DESCRIPTION
…_API

Excluding this and only including the IP of the Connect Service pod was causing an error to be thrown by the Hashicorp Vault plugin that wasn't particularly clear:
```
Unable to list vaults: Get "192.168.1.1/v1/vaults": unsupported protocol scheme ""
```