### PR TITLE
Fix quickstart local installation for better transition to usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ vault server -dev -dev-root-token-id=root -dev-plugin-dir=./vault/plugins -log-l
 Enable the plugin:
 
 ```bash
-vault secrets enable op-connect
+vault secrets enable --path="op" op-connect
 ```
 
 To check if your plugin has been registered you should be able to see the plugin when listing all registered plugins:


### PR DESCRIPTION
With the current installation process, the commands shown as examples in the `Usage` section would not work. This can be confusing for users who want to locally try out the plugin. With this change, both local and normal installation transition nicely to the `Usage` section.