### PR TITLE
Fix database example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,22 +236,20 @@ Example Database Item:
       "id": "username",
       "label": "username",
       "type": "STRING",
-      "purpose": "USERNAME",
       "value": "my_user"
     },
     {
       "id": "password",
       "label": "password",
-      "purpose": "PASSWORD",
       "type": "CONCEALED",
       "value": "",
       "generate": true
     },
     {
       "id": "hostname",
-      "label": "hostname",
+      "label": "server",
       "type": "STRING",
-      "value": "my_host"
+      "value": "http://my_host"
     },
     {
       "id": "database",
@@ -264,6 +262,18 @@ Example Database Item:
       "label": "port",
       "type": "STRING",
       "value": "8080"
+    },
+    {
+      "id": "database",
+      "label": "database",
+      "type": "STRING",
+      "value": "my-database"
+    },
+    {
+      "id": "database_type",
+      "label": "type",
+      "type": "MENU",
+      "value": "mysql"
     }
   ]
 }


### PR DESCRIPTION
After quite a bit of fighting with a '406 not accepted' error, I found out that removing the 'purpose' fields from the username and password got it working.

```
1 error occurred:
	* Unable to create item: Unable to create item. Receieved \"406 Not Acceptable\" for \"/v1/vaults/5jzejthcprrewjbeyl5hvvocwy/items\"
```

I've also added some other important fields which I found from using `op item template get database`; `database` and `database_type`.